### PR TITLE
Neptune client tests moved to tests subdirectory

### DIFF
--- a/configs/neptune-ai/lightning_integration.yaml
+++ b/configs/neptune-ai/lightning_integration.yaml
@@ -4,13 +4,13 @@ target_repository:
   checkout: master
   # copy some  test from the target repository
   copy_tests:
-    - e2e_tests/integrations/__init__.py
-    - e2e_tests/integrations/test_lightning.py
-    - e2e_tests/conftest.py
-    - e2e_tests/base.py
-    - e2e_tests/utils.py
-    - e2e_tests/exceptions.py
-    - e2e_tests/pytest.ini
+    - tests/e2e/integrations/__init__.py
+    - tests/e2e/integrations/test_lightning.py
+    - tests/e2e/conftest.py
+    - tests/e2e/base.py
+    - tests/e2e/utils.py
+    - tests/e2e/exceptions.py
+    - tests/e2e/pytest.ini
 
 contact:
   slack:
@@ -32,7 +32,7 @@ dependencies:
 
 testing:
   dirs:
-    - e2e_tests
+    - tests/e2e
   # OPTIONAL, additional pytest arguments
   pytest_args: -m lightning
 


### PR DESCRIPTION
## Before submitting

- [ ] Was this discussed/approved via a GitHub issue? (no need for typos and docs improvements)
- [x] Did you create/update your **configuration file**?
- [x] Did you **set `runtimes` in config** for GitHub action integration?
- [x] Did you **add your config to CI** in Azure pipeline (only projects with 100+ GitHub stars)?
- [ ] Are all integration **tests passing**?

## What does this PR do? \[optional\]

We moved our e2e tests from `e2e_tests` under `tests` directory.

## Did you have fun?
Of course :rocket:
