### PR TITLE
fix watcher

### DIFF
--- a/.github/workflows/ci_compatible.yml
+++ b/.github/workflows/ci_compatible.yml
@@ -112,8 +112,16 @@ jobs:
   watcher:
     runs-on: ubuntu-latest
     needs: pytester
+    if: always()
     steps:
     - run: echo "${{ needs.pytester.result }}"
+    - name: failing...
+      if: needs.pytester.result == 'failure'
+      run: exit 1
+    - name: cancelled or skipped...
+      if: contains(fromJSON('["cancelled", "skipped"]'), needs.pytester.result)
+      timeout-minutes: 1
+      run: sleep 90
 
 
   messenger:

--- a/_actions/_config.yaml
+++ b/_actions/_config.yaml
@@ -57,4 +57,4 @@ testing:
 runtimes:
   - {os: "ubuntu-20.04", python: "3.9"}
   - {os: "macOS-10.15", python: "3.7"}
-#  - {os: "windows-2019", python: "3.8"}  # SKIP, because of the wget
+  - {os: "windows-2019", python: "3.8"}  # SKIP, because of the wget

--- a/_actions/_config.yaml
+++ b/_actions/_config.yaml
@@ -57,4 +57,4 @@ testing:
 runtimes:
   - {os: "ubuntu-20.04", python: "3.9"}
   - {os: "macOS-10.15", python: "3.7"}
-  - {os: "windows-2019", python: "3.8"}  # SKIP, because of the wget
+#  - {os: "windows-2019", python: "3.8"}  # SKIP, because of the wget

--- a/_actions/assistant.py
+++ b/_actions/assistant.py
@@ -48,7 +48,7 @@ class AssistantCLI:
     _FOLDER_TESTS = "_integrations"
     _PATH_CONFIGS = os.path.join(_PATH_ROOT, "configs")
     _STATUS_SIGN = dict(
-        success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:"
+        success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:",
     )
 
     @staticmethod

--- a/_actions/assistant.py
+++ b/_actions/assistant.py
@@ -48,7 +48,10 @@ class AssistantCLI:
     _FOLDER_TESTS = "_integrations"
     _PATH_CONFIGS = os.path.join(_PATH_ROOT, "configs")
     _STATUS_SIGN = dict(
-        success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:",
+        success=":white_check_mark:",
+        failure=":x:",
+        cancelled=":no_entry_sign:",
+        skipped=":grey_question:",
     )
 
     @staticmethod

--- a/_actions/assistant.py
+++ b/_actions/assistant.py
@@ -47,7 +47,9 @@ class AssistantCLI:
     _MANDATORY_FIELDS = (_FIELD_TARGET_REPO, _FIELD_REQUIRE)
     _FOLDER_TESTS = "_integrations"
     _PATH_CONFIGS = os.path.join(_PATH_ROOT, "configs")
-    _STATUS_SIGN = dict(success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:")
+    _STATUS_SIGN = dict(
+        success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:"
+    )
 
     @staticmethod
     def folder_local_tests() -> str:

--- a/_actions/assistant.py
+++ b/_actions/assistant.py
@@ -47,7 +47,7 @@ class AssistantCLI:
     _MANDATORY_FIELDS = (_FIELD_TARGET_REPO, _FIELD_REQUIRE)
     _FOLDER_TESTS = "_integrations"
     _PATH_CONFIGS = os.path.join(_PATH_ROOT, "configs")
-    _STATUS_SIGN = dict(success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:")
+    _STATUS_SIGN = dict(success=":white_check_mark:", failure=":x:", cancelled=":no_entry_sign:", skipped=":grey_question:")
 
     @staticmethod
     def folder_local_tests() -> str:


### PR DESCRIPTION
## Before submitting

- [x] Was this discussed/approved via a GitHub issue? (no need for typos and docs improvements)
- [ ] Did you create/update your **configuration file**?
- [ ] Did you **set `runtimes` in config** for GitHub action integration?
- [ ] Did you **add your config to CI** in Azure pipeline (only projects with 100+ GitHub stars)?
- [x] Are all integration **tests passing**?

## What does this PR do? \[optional\]

Turned out that for failing `pytester` this `watcher` is skipped not failed...

## Did you have fun?

Make sure you had fun coding 🙃
