### PR TITLE
ci: source CUDA ver. from nvcc

### DIFF
--- a/.azure/testing-template.yml
+++ b/.azure/testing-template.yml
@@ -51,7 +51,9 @@ jobs:
 
     - bash: |
         echo "##vso[task.setvariable variable=CUDA_VISIBLE_DEVICES]$(DEVICES)"
-        CUDA_version=$(nvidia-smi | sed -n 's/^.*CUDA Version: \([0-9]\+\.[0-9]\+\).*$/\1/p')
+        # See reason why not to source `nvidia-smi`: https://github.com/NVIDIA/nvidia-docker/issues/1237
+        # BUT `nvcc` is missing in runtime docker images...
+        CUDA_version=$(nvcc --version | sed -n 's/^.*release \([0-9]\+\.[0-9]\+\).*$/\1/p')
         CUDA_version_mm="${CUDA_version//'.'/''}"
         echo "##vso[task.setvariable variable=CUDA_VERSION_MM]$CUDA_version_mm"
         echo "##vso[task.setvariable variable=TORCH_URL]https://download.pytorch.org/whl/cu${CUDA_version_mm}/torch_stable.html"

--- a/.azure/testing-template.yml
+++ b/.azure/testing-template.yml
@@ -50,6 +50,14 @@ jobs:
     steps:
 
     - bash: |
+        echo "##vso[task.setvariable variable=CUDA_VISIBLE_DEVICES]$(DEVICES)"
+        CUDA_version=$(nvidia-smi | sed -n 's/^.*CUDA Version: \([0-9]\+\.[0-9]\+\).*$/\1/p')
+        CUDA_version_mm="${CUDA_version//'.'/''}"
+        echo "##vso[task.setvariable variable=CUDA_VERSION_MM]$CUDA_version_mm"
+        echo "##vso[task.setvariable variable=TORCH_URL]https://download.pytorch.org/whl/cu${CUDA_version_mm}/torch_stable.html"
+      displayName: 'set Env. vars'
+
+    - bash: |
         whoami && id
         lspci | egrep 'VGA|3D'
         whereis nvidia
@@ -57,12 +65,11 @@ jobs:
         python --version
         pip --version
         pip list
-        python -c "import torch ; print(torch.cuda.get_arch_list())"
-        echo "##vso[task.setvariable variable=CUDA_VISIBLE_DEVICES]$(DEVICES)"
       displayName: 'Image info & NVIDIA'
 
     - script: |
         container_id=$(head -1 /proc/self/cgroup|cut -d/ -f3)
+        echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
         /tmp/docker exec -t -u 0 $container_id \
           sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
         echo "##vso[task.setvariable variable=CONTAINER_ID]$container_id"
@@ -80,6 +87,7 @@ jobs:
     - bash: |
         echo $CUDA_VISIBLE_DEVICES
         echo $CONTAINER_ID
+        python -c "import torch ; print(torch.cuda.get_arch_list())"
         python -c "import torch ; mgpu = torch.cuda.device_count() ; assert mgpu > 0, f'GPU: {mgpu}'"
       displayName: 'Sanity check'
 

--- a/.azure/testing-template.yml
+++ b/.azure/testing-template.yml
@@ -50,26 +50,22 @@ jobs:
     steps:
 
     - bash: |
-        echo "##vso[task.setvariable variable=CONTAINER_ID]$(head -1 /proc/self/cgroup|cut -d/ -f3)"
-        echo "##vso[task.setvariable variable=CUDA_VISIBLE_DEVICES]$(DEVICES)"
-      displayName: 'Set environment variables'
-
-    - bash: |
         whoami && id
         lspci | egrep 'VGA|3D'
         whereis nvidia
         nvidia-smi
-        echo $CUDA_VISIBLE_DEVICES
-        echo $CONTAINER_ID
         python --version
         pip --version
         pip list
         python -c "import torch ; print(torch.cuda.get_arch_list())"
+        echo "##vso[task.setvariable variable=CUDA_VISIBLE_DEVICES]$(DEVICES)"
       displayName: 'Image info & NVIDIA'
 
     - script: |
-        /tmp/docker exec -t -u 0 $CONTAINER_ID \
-        sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+        container_id=$(head -1 /proc/self/cgroup|cut -d/ -f3)
+        /tmp/docker exec -t -u 0 $container_id \
+          sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+        echo "##vso[task.setvariable variable=CONTAINER_ID]$container_id"
       displayName: 'Install Sudo in container (thanks Microsoft!)'
 
     - bash: |
@@ -82,6 +78,8 @@ jobs:
       displayName: 'Install dependencies'
 
     - bash: |
+        echo $CUDA_VISIBLE_DEVICES
+        echo $CONTAINER_ID
         python -c "import torch ; mgpu = torch.cuda.device_count() ; assert mgpu > 0, f'GPU: {mgpu}'"
       displayName: 'Sanity check'
 


### PR DESCRIPTION
## What does this PR do?

Use `nvcc` instead of `torch` to source base CUDA docker images.
See the reason why not to source `nvidia-smi`: https://github.com/NVIDIA/nvidia-container-toolkit/issues/300
BUT `nvcc` is missing in runtime docker images...

<details>
  <summary>Before submitting</summary>

- [x] Was this discussed/agreed via a GitHub issue? (no need for typos and docs improvements)
- [ ] Did you create/update your **configuration file**? (in case you are adding new integration)
- Did you **set `runtimes` in config** for GitHub action integration?
- [ ] Are all integration **tests passing**?

</details>

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->
