### PR TITLE
Update (ci): github action's artifact upgrade v4

### DIFF
--- a/.github/actions/job-dump/action.yml
+++ b/.github/actions/job-dump/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: meta.json

--- a/.github/workflows/ci_compatible.yml
+++ b/.github/workflows/ci_compatible.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run: echo "[]" > projects.json
       - name: Upload placeholder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compatibility-${{ github.sha }}
           path: projects.json
@@ -81,31 +81,36 @@ jobs:
       matrix: ${{ fromJSON(needs.generator.outputs.matrix) }}
     steps:
       - name: Download 📥 summary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compatibility-${{ github.sha }}
       - name: Download 📥 project
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        id: download-project
         with:
-          name: project-${{ github.sha }}-${{ strategy.job-index }}
+          pattern: project-${{ github.sha }}-*
 
       - run: ls -l
       - name: append result
         run: |
           import json
+          import os
           with open("projects.json") as fp:
             data = json.load(fp)
-          with open("meta.json") as fp:
-            data.append(json.load(fp))
+          for root, dirs, files in os.walk("${{ steps.download-project.outputs.download-path }}"):
+            if "meta.json" in files:
+              with open(root+"/meta.json") as fp:
+                data.append(json.load(fp))
           with open("projects.json", "w") as fp:
             json.dump(data, fp)
         shell: python
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compatibility-${{ github.sha }}
           path: projects.json
+          overwrite: true
 
   watcher:
     runs-on: ubuntu-latest
@@ -129,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download 📥 summary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compatibility-${{ github.sha }}
       - run: cat projects.json
@@ -170,7 +175,7 @@ jobs:
           git config user.email github-actions@github.com
           git merge origin/main
       - name: Download 📥 summary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compatibility-${{ github.sha }}
       - name: Update results

--- a/_actions/_config.yaml
+++ b/_actions/_config.yaml
@@ -40,7 +40,7 @@ dependencies:
     install_flags:
       - "--find-links https://download.pytorch.org/whl/cpu/torch_stable.html"
   - name: typing_extensions
-    checkout: 4.1.1
+    checkout: 4.7.1
     install_flags: "--use-pep517"
 
 # OPTIONAL, running before installing your project


### PR DESCRIPTION
## What does this PR do?
- Updates GitHub actions's artifacts from v3 to v4
- Add overwrite true for the compatibility json after appending
- Bump typing_extensions since it shows breaking after updating artifacts which is currently breaking main https://github.com/Lightning-AI/ecosystem-ci/actions/runs/12383849406/job/34567364146#step:4:1

Fixes # <issue> (add a link to the created issue in your repository if any)
OR link your project for clarity.

We received the email below stating that we need to upgrade by January.

![image](https://github.com/user-attachments/assets/91ad1e42-6353-4781-a4f6-d689a419da92)


[Here is the recommended upgrade guide that I followed. 
](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility)

### Does this introduce breaking change?

-  > In v4, Artifacts are immutable (unless deleted). So you must change each of the uploaded Artifacts to have a different name and filter the downloads by name to achieve the same effect:

- - Since we are only uploading one artifact, it is fine. If we introduce a list, we will need to modify the name.

- According to Github after Jan 9th if we have not upgraded there will be issues running pipelines.



<details>
  <summary>Before submitting</summary>

- [ ] Was this discussed/agreed via a GitHub issue? (no need for typos and docs improvements)
- [ ] Did you create/update your **configuration file**? (in case you are adding new integration)
- Did you **set `runtimes` in config** for GitHub action integration?
- [ ] Are all integration **tests passing**?

</details>

<!--
Did you have fun?

Make sure you had fun coding 🙃
-->
